### PR TITLE
Add alternate constructor to user can specify modified OkHttpClient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,11 @@
   		<version>1.0.2</version>
   	</dependency>
   	<dependency>
+  		<groupId>com.squareup.okhttp</groupId>
+  		<artifactId>okhttp</artifactId>
+  		<version>1.6.0</version>
+  	</dependency>
+  	<dependency>
   		<groupId>oauth.signpost</groupId>
   		<artifactId>signpost-core</artifactId>
   		<version>1.2.1.2</version>

--- a/src/main/java/se/akerfeldt/signpost/retrofit/SigningOkClient.java
+++ b/src/main/java/se/akerfeldt/signpost/retrofit/SigningOkClient.java
@@ -17,6 +17,7 @@ package se.akerfeldt.signpost.retrofit;
 
 import java.io.IOException;
 
+import com.squareup.okhttp.OkHttpClient;
 import oauth.signpost.exception.OAuthCommunicationException;
 import oauth.signpost.exception.OAuthExpectationFailedException;
 import oauth.signpost.exception.OAuthMessageSignerException;
@@ -34,6 +35,11 @@ public class SigningOkClient extends OkClient {
 	private final RetrofitHttpOAuthConsumer mOAuthConsumer;
 	
 	public SigningOkClient(RetrofitHttpOAuthConsumer consumer) {
+		mOAuthConsumer = consumer;
+	}
+
+	public SigningOkClient(OkHttpClient client, RetrofitHttpOAuthConsumer consumer) {
+        super(client);
 		mOAuthConsumer = consumer;
 	}
 	


### PR DESCRIPTION
We needed to modify the read timeout of the OkHttpClient while still using this library, and were unable to do so without adding this constructor.
