### PR TITLE
Make OkHttpClient transient to allow serialization

### DIFF
--- a/src/main/java/se/akerfeldt/okhttp/signpost/OkHttpOAuthProvider.java
+++ b/src/main/java/se/akerfeldt/okhttp/signpost/OkHttpOAuthProvider.java
@@ -28,7 +28,7 @@ import oauth.signpost.http.HttpResponse;
  */
 public class OkHttpOAuthProvider extends AbstractOAuthProvider {
 
-    private OkHttpClient okHttpClient;
+    private transient OkHttpClient okHttpClient;
 
     /**
      * Constructs a new {@code OkHttpOAuthProvider} with a default {@link OkHttpClient}.


### PR DESCRIPTION
Making OkHttpClient transient allow serialization of the class and you can pass around all the OAuth config in an intent in Android.

It also follows the pattern of other providers like [commonshttp](https://github.com/mttkay/signpost/blob/master/signpost-commonshttp4/src/main/java/oauth/signpost/commonshttp/CommonsHttpOAuthProvider.java) and eases the migration from apache to okhttp.