### PR TITLE
using basic authorization when the request is https. If http, same as previous behavior.

### DIFF
--- a/src/main/java/se/akerfeldt/okhttp/signpost/OkHttpOAuthConsumerUsingBasicAuthAtHttps.java
+++ b/src/main/java/se/akerfeldt/okhttp/signpost/OkHttpOAuthConsumerUsingBasicAuthAtHttps.java
@@ -1,0 +1,44 @@
+package se.akerfeldt.okhttp.signpost;
+
+import oauth.signpost.exception.OAuthCommunicationException;
+import oauth.signpost.exception.OAuthExpectationFailedException;
+import oauth.signpost.exception.OAuthMessageSignerException;
+import oauth.signpost.http.HttpRequest;
+import okhttp3.Request;
+import org.apache.commons.codec.binary.Base64;
+
+/**
+ * {@code OkHttpOAuthConsumerUsingBasicAuthAtHttps} is a {@link oauth.signpost.OAuthConsumer} implementation capable of handling OkHttp
+ * {@link Request}s. If the request is https, this uses basic authorization.
+ */
+public class OkHttpOAuthConsumerUsingBasicAuthAtHttps extends OkHttpOAuthConsumer {
+
+    private String encodedAuthStr;
+
+    /**
+     * Constructs a new {@code OkHttpOAuthConsumerUsingBasicAuthAtHttps}.
+     * @param consumerKey the consumer key.
+     * @param consumerSecret the consumer secret.
+     */
+    public OkHttpOAuthConsumerUsingBasicAuthAtHttps(String consumerKey, String consumerSecret) {
+        super(consumerKey, consumerSecret);
+
+        String authStr = getConsumerKey() + ":" + getConsumerSecret();
+        encodedAuthStr = new String(Base64.encodeBase64(authStr.getBytes()));
+    }
+
+    public synchronized HttpRequest sign(Object request) throws OAuthMessageSignerException, OAuthExpectationFailedException, OAuthCommunicationException {
+        return this.sign(this.wrap(request));
+    }
+
+    public synchronized HttpRequest sign(HttpRequest request) throws OAuthMessageSignerException, OAuthExpectationFailedException, OAuthCommunicationException {
+        if (request.getRequestUrl().startsWith("https://")) {
+            request.setHeader("Authorization", "Basic " + encodedAuthStr);
+
+            return request;
+        } else {
+            return super.sign(request);
+        }
+    }
+
+}


### PR DESCRIPTION
A specific HTTP REST APIs like Wordpress's woocommerce API hebave differently according to protocol.
If it is http, use oauth 1.0.
If it is https, use basic authorization.

So, I made a integration class.  

using basic authorization when the request is https.
If http, same as previous behavior.