### PR TITLE
escape illegal characters in request

### DIFF
--- a/src/main/java/se/akerfeldt/okhttp/signpost/OkHttpRequestAdapter.java
+++ b/src/main/java/se/akerfeldt/okhttp/signpost/OkHttpRequestAdapter.java
@@ -80,7 +80,7 @@ public class OkHttpRequestAdapter implements HttpRequest {
 
     @Override
     public String getRequestUrl() {
-        return request.url().toString();
+        return request.url().uri().toString();
     }
 
     @Override


### PR DESCRIPTION
If for example request query contained characters like "|", SignPost could not sign it:
`oauth.signpost.exception.OAuthMessageSignerException: java.net.URISyntaxException: Illegal character (...)`

So basically the problem is that SignPost can't create URI from URL/String that contains illegal characters.

Solution is to simply manually create URI, encoding/escaping everything, and then convert it to String and pass to SignPost. Fortunately, OkHttp has a convenient method for that ;).
