### PR TITLE
Close the response to avoid connection leaks.

### DIFF
--- a/src/main/java/se/akerfeldt/okhttp/signpost/OkHttpOAuthProvider.java
+++ b/src/main/java/se/akerfeldt/okhttp/signpost/OkHttpOAuthProvider.java
@@ -64,4 +64,12 @@ public class OkHttpOAuthProvider extends AbstractOAuthProvider {
         Response response = okHttpClient.newCall((Request) request.unwrap()).execute();
         return new OkHttpResponseAdapter(response);
     }
+
+    @Override
+    protected void closeConnection(HttpRequest request, HttpResponse response) throws Exception {
+        if (response != null) {
+            Response r = (Response) response.unwrap();
+            r.close();
+        }
+    }
 }


### PR DESCRIPTION
Properly release the resources to avoid connection leaks in OkHttp:
> [2018-xx-xx xx:xx:xx] [WARNING] [okhttp3.internal.platform.Platform log] - A connection to xxx was leaked. Did you forget to close a response body?
