### PR TITLE
adding proxy url support for signing via header

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
   <groupId>se.akerfeldt</groupId>
   <artifactId>okhttp-signpost</artifactId>
-  <version>1.1.1-SNAPSHOT</version>
+  <version>1.1.2</version>
 
 
   <name>OkHttp Signpost</name>

--- a/src/main/java/se/akerfeldt/okhttp/signpost/OkHttpRequestAdapter.java
+++ b/src/main/java/se/akerfeldt/okhttp/signpost/OkHttpRequestAdapter.java
@@ -80,6 +80,9 @@ public class OkHttpRequestAdapter implements HttpRequest {
 
     @Override
     public String getRequestUrl() {
+        if (this.request.header("X-PROXY-CUSTOM-URL") != null) {
+            return this.request.header("X-PROXY-CUSTOM-URL");
+        }
         return request.url().toString();
     }
 


### PR DESCRIPTION
If there is HTTP proxy (forward proxy) is present in the network, connects to the service provider domain, then your app has to use a proxy domain. For such cases, signing has to happen with the service provider domain, not with HTTP proxy domain.